### PR TITLE
Add confirmation to guess buttons

### DIFF
--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -35,6 +35,9 @@
     "counterguess": {
         "more_left": "Ziel ist weiter links",
         "more_right": "Ziel ist weiter rechts",
+        "confirm_more_left": "Bestätigen: Ziel ist weiter links",
+        "confirm_more_right": "Bestätigen: Ziel ist weiter rechts",
+        "cancel": "Abbrechen",
         "players_clue": "{{givername}}'s Hinweis",
         "waiting_guess_team": "Warte auf den Rateversuche links/rechts von Team {{guessteam}}..."
     },
@@ -65,7 +68,9 @@
         "waiting_guessing_team": "Warte auf den Rateversuch von Team {{guessingteam}}...",
         "invite_other_players": "Lade weitere Spieler zu diesem Spiel ein.",
         "share_game_url": "Teile diese Adresse mit ihnen: {{game_url}}",
-        "guess_for_team": "Rate für das Team {{teamname}}"
+        "guess_for_team": "Rate für das Team {{teamname}}",
+        "confirm_guess_for_team": "Bestätigen: Rate für {{teamname}}",
+        "cancel": "Abbrechen"
     },
     "previousturnresult": {
         "previous_game": "Vorheriges Spiel",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -35,6 +35,9 @@
   "counterguess": {
     "more_left": "Target is to the left",
     "more_right": "Target is to the right",
+    "confirm_more_left": "Confirm: Target is to the left",
+    "confirm_more_right": "Confirm: Target is to the right",
+    "cancel": "Cancel",
     "players_clue": "{{givername}}'s clue",
     "waiting_guess_team": "Waiting for {{guessteam}} to guess left/right..."
   },
@@ -65,7 +68,9 @@
     "waiting_guessing_team": "Waiting for {{guessingteam}} to guess...",
     "invite_other_players": "Invite other players to join the game.",
     "share_game_url": "Share this URL with them: {{game_url}}",
-    "guess_for_team": "Submit Guess for {{teamname}}"
+    "guess_for_team": "Submit Guess for {{teamname}}",
+    "confirm_guess_for_team": "Confirm Guess for {{teamname}}",
+    "cancel": "Cancel"
   },
   "previousturnresult": {
     "previous_game": "Previous Turn",

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -35,6 +35,9 @@
   "counterguess": {
     "more_left": "El objetivo está a la izquierda",
     "more_right": "El objetivo está a la derecha",
+    "confirm_more_left": "Confirmar: El objetivo está a la izquierda",
+    "confirm_more_right": "Confirmar: El objetivo está a la derecha",
+    "cancel": "Cancelar",
     "players_clue": "Pista de {{givername}}",
     "waiting_guess_team": "Esperando a que el {{guessteam}} decida si derecha o izquierda..."
   },
@@ -65,7 +68,9 @@
     "waiting_guessing_team": "Esperando a que el {{guessingteam}} decida...",
     "invite_other_players": "Invita a otros jugadores a unirse a la partida.",
     "share_game_url": "Comparte esta URL con ellos: {{game_url}}",
-    "guess_for_team": "Enviar la respuesta del {{teamname}}"
+    "guess_for_team": "Enviar la respuesta del {{teamname}}",
+    "confirm_guess_for_team": "Confirmar respuesta del {{teamname}}",
+    "cancel": "Cancelar"
   },
   "previousturnresult": {
     "previous_game": "Turno anterior",

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -31,6 +31,9 @@
   "counterguess": {
     "more_left": "La cible est sur la gauche",
     "more_right": "La cible est sur la droite",
+    "confirm_more_left": "Confirmer : la cible est sur la gauche",
+    "confirm_more_right": "Confirmer : la cible est sur la droite",
+    "cancel": "Annuler",
     "players_clue": "Indice fourni par {{givername}}",
     "waiting_guess_team": "En attente d'une déduction de positionnement à fournir par {{guessteam}}..."
   },
@@ -61,7 +64,9 @@
     "waiting_guessing_team": "En attente d'une déduction par {{guessingteam}}...",
     "invite_other_players": "Inviter d'autres joueurs à rejoindre la partie.",
     "share_game_url": "Partager cette URL avec eux : {{game_url}}",
-    "guess_for_team": "Envoyer votre déduction pour {{teamname}}"
+    "guess_for_team": "Envoyer votre déduction pour {{teamname}}",
+    "confirm_guess_for_team": "Confirmer la déduction pour {{teamname}}",
+    "cancel": "Annuler"
   },
   "previousturnresult": {
     "previous_game": "Tour précédent",

--- a/public/locales/it/translation.json
+++ b/public/locales/it/translation.json
@@ -35,6 +35,9 @@
   "counterguess": {
     "more_left": "Il target si trova sulla sinistra",
     "more_right": "Il target si trova sulla destra",
+    "confirm_more_left": "Conferma: il target è sulla sinistra",
+    "confirm_more_right": "Conferma: il target è sulla destra",
+    "cancel": "Annulla",
     "players_clue": "L'indizio di {{givername}}",
     "waiting_guess_team": "In attesa che il team {{guessteam}} indovini destra/sinistra..."
   },
@@ -65,7 +68,9 @@
     "waiting_guessing_team": "In attesa che la squadra {{guessingteam}} indovini...",
     "invite_other_players": "Invita altri giocatori ad unirsi alla partita.",
     "share_game_url": "Condividi questo URL con loro: {{game_url}}",
-    "guess_for_team": "Conferma ipotesi per la squadra {{teamname}}"
+    "guess_for_team": "Conferma ipotesi per la squadra {{teamname}}",
+    "confirm_guess_for_team": "Conferma definitiva per {{teamname}}",
+    "cancel": "Annulla"
   },
   "previousturnresult": {
     "previous_game": "Turno precedente",

--- a/public/locales/pt/translation.json
+++ b/public/locales/pt/translation.json
@@ -31,6 +31,9 @@
   "counterguess": {
     "more_left": "O alvo está a esquerda",
     "more_right": "O alvo está a direita",
+    "confirm_more_left": "Confirmar: o alvo está à esquerda",
+    "confirm_more_right": "Confirmar: o alvo está à direita",
+    "cancel": "Cancelar",
     "players_clue": "dica de {{givername}}",
     "waiting_guess_team": "Esperando por {{guessteam}} para responder esquerda/direita..."
   },
@@ -61,7 +64,9 @@
     "waiting_guessing_team": "Esperando {{guessingteam}} responder...",
     "invite_other_players": "Convidar outros jogadores para a partida.",
     "share_game_url": "Compartilhe esse endereço: {{game_url}}",
-    "guess_for_team": "Enviar resposta por {{teamname}}"
+    "guess_for_team": "Enviar resposta por {{teamname}}",
+    "confirm_guess_for_team": "Confirmar resposta por {{teamname}}",
+    "cancel": "Cancelar"
   },
   "previousturnresult": {
     "previous_game": "Turno Anterior",

--- a/src/components/gameplay/CounterGuess.tsx
+++ b/src/components/gameplay/CounterGuess.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from "react";
+import React, { useContext, useState } from "react";
 import { TeamReverse, TeamName } from "../../state/GameState";
 import { Spectrum } from "../common/Spectrum";
 import { CenteredColumn, CenteredRow } from "../common/LayoutElements";
@@ -18,6 +18,7 @@ export function CounterGuess() {
     spectrumCard,
     setGameState,
   } = useContext(GameModelContext);
+  const [pendingDirection, setPendingDirection] = useState<"left" | "right" | null>(null);
 
   if (!clueGiver) {
     return null;
@@ -56,18 +57,42 @@ export function CounterGuess() {
         </div>
       </CenteredColumn>
       <CenteredRow>
-        <Button
-          text={t("counterguess.more_left") as string}
-          onClick={() =>
-            setGameState(ScoreTeamRound(gameState, clueGiver.team, "left"))
-          }
-        />
-        <Button
-          text={t("counterguess.more_right") as string}
-          onClick={() =>
-            setGameState(ScoreTeamRound(gameState, clueGiver.team, "right"))
-          }
-        />
+        {pendingDirection === null && (
+          <>
+            <Button
+              text={t("counterguess.more_left") as string}
+              onClick={() => setPendingDirection("left")}
+            />
+            <Button
+              text={t("counterguess.more_right") as string}
+              onClick={() => setPendingDirection("right")}
+            />
+          </>
+        )}
+        {pendingDirection !== null && (
+          <>
+            <Button
+              text={
+                pendingDirection === "left"
+                  ? (t("counterguess.confirm_more_left") as string)
+                  : (t("counterguess.confirm_more_right") as string)
+              }
+              onClick={() =>
+                setGameState(
+                  ScoreTeamRound(
+                    gameState,
+                    clueGiver.team,
+                    pendingDirection === "left" ? "left" : "right"
+                  )
+                )
+              }
+            />
+            <Button
+              text={t("counterguess.cancel") as string}
+              onClick={() => setPendingDirection(null)}
+            />
+          </>
+        )}
       </CenteredRow>
     </div>
   );

--- a/src/components/gameplay/MakeGuess.tsx
+++ b/src/components/gameplay/MakeGuess.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from "react";
+import React, { useContext, useState } from "react";
 import { GameType, RoundPhase, TeamName } from "../../state/GameState";
 import { Spectrum } from "../common/Spectrum";
 import { CenteredColumn } from "../common/LayoutElements";
@@ -13,6 +13,7 @@ export function MakeGuess() {
   const { t } = useTranslation();
   const { gameState, localPlayer, clueGiver, spectrumCard, setGameState } =
     useContext(GameModelContext);
+  const [confirming, setConfirming] = useState(false);
 
   if (!clueGiver) {
     return null;
@@ -71,6 +72,7 @@ export function MakeGuess() {
           setGameState({
             guess,
           });
+          setConfirming(false);
         }}
       />
       <CenteredColumn>
@@ -79,31 +81,47 @@ export function MakeGuess() {
           <strong>{gameState.clue}</strong>
         </div>
         <div>
-          <Button
-            text={t("makeguess.guess_for_team", {
-              teamname: TeamName(localPlayer.team, t),
-            })}
-            onClick={() => {
-              RecordEvent("guess_submitted", {
-                spectrum_card: spectrumCard.join("|"),
-                clue: gameState.clue,
-                target: gameState.spectrumTarget.toString(),
-                guess: gameState.guess.toString(),
-              });
+          {!confirming ? (
+            <Button
+              text={t("makeguess.guess_for_team", {
+                teamname: TeamName(localPlayer.team, t),
+              })}
+              onClick={() => setConfirming(true)}
+            />
+          ) : (
+            <>
+              <Button
+                text={t("makeguess.confirm_guess_for_team", {
+                  teamname: TeamName(localPlayer.team, t),
+                })}
+                onClick={() => {
+                  RecordEvent("guess_submitted", {
+                    spectrum_card: spectrumCard.join("|"),
+                    clue: gameState.clue,
+                    target: gameState.spectrumTarget.toString(),
+                    guess: gameState.guess.toString(),
+                  });
 
-              if (gameState.gameType === GameType.Teams) {
-                setGameState({
-                  roundPhase: RoundPhase.CounterGuess,
-                });
-              } else if (gameState.gameType === GameType.Cooperative) {
-                setGameState(ScoreCoopRound(gameState));
-              } else {
-                setGameState({
-                  roundPhase: RoundPhase.ViewScore,
-                });
-              }
-            }}
-          />
+                  if (gameState.gameType === GameType.Teams) {
+                    setGameState({
+                      roundPhase: RoundPhase.CounterGuess,
+                    });
+                  } else if (gameState.gameType === GameType.Cooperative) {
+                    setGameState(ScoreCoopRound(gameState));
+                  } else {
+                    setGameState({
+                      roundPhase: RoundPhase.ViewScore,
+                    });
+                  }
+                  setConfirming(false);
+                }}
+              />
+              <Button
+                text={t("makeguess.cancel") as string}
+                onClick={() => setConfirming(false)}
+              />
+            </>
+          )}
         </div>
       </CenteredColumn>
     </div>


### PR DESCRIPTION
Add a second confirmation step to guess submission and counter-guess actions to prevent accidental submissions that lock teams into a guess.

---
<a href="https://cursor.com/background-agent?bcId=bc-25d97d23-43da-41bc-86a7-0f3ae9462f32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-25d97d23-43da-41bc-86a7-0f3ae9462f32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

