### PR TITLE
Allow custom team names for game master

### DIFF
--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -59,6 +59,8 @@
         "join_team": "Team beitreten",
         "join_left": "Beitreten",
         "join_right": "Beitreten",
+        "left_team_name": "Name linkes Team",
+        "right_team_name": "Name rechtes Team",
         "start_game": "Starte Spiel",
         "creator_is_observer": "Du hast diesen Raum erstellt und verfolgst als Spielleiter. Du trittst keinem Team bei und gibst keine Hinweise/Tipps ab.",
         "only_creator_can_start": "Nur der Spielleiter kann das Spiel starten."

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -59,6 +59,8 @@
     "join_team": "Join Team",
     "join_left": "Join",
     "join_right": "Join",
+    "left_team_name": "Left team name",
+    "right_team_name": "Right team name",
     "start_game": "Start game",
     "creator_is_observer": "You created this room and are following along as Game Master. You won't join a team or submit clues/guesses.",
     "only_creator_can_start": "Only the game master can start the game."

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -59,6 +59,8 @@
     "join_team": "Únete a un equipo",
     "join_left": "Unirse",
     "join_right": "Unirse",
+    "left_team_name": "Nombre del equipo izquierdo",
+    "right_team_name": "Nombre del equipo derecho",
     "start_game": "Empezar partida",
     "creator_is_observer": "Creaste esta sala y seguirás como Maestro del juego. No te unirás a un equipo ni enviarás pistas o respuestas.",
     "only_creator_can_start": "Solo el maestro del juego puede iniciar la partida."

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -55,6 +55,8 @@
     "join_team": "Rejoindre une Équipe",
     "join_left": "Rejoindre",
     "join_right": "Rejoindre",
+    "left_team_name": "Nom de l'équipe gauche",
+    "right_team_name": "Nom de l'équipe droite",
     "start_game": "Démarrer la partie",
     "creator_is_observer": "Vous avez créé ce salon et suivez la partie comme Maître du jeu. Vous ne rejoindrez pas d'équipe et ne soumettrez pas d'indices/déductions.",
     "only_creator_can_start": "Seul le maître du jeu peut démarrer la partie."

--- a/public/locales/it/translation.json
+++ b/public/locales/it/translation.json
@@ -59,6 +59,8 @@
     "join_team": "Unisciti alla squadra",
     "join_left": "Unisciti",
     "join_right": "Unisciti",
+    "left_team_name": "Nome squadra sinistra",
+    "right_team_name": "Nome squadra destra",
     "start_game": "Avvia gioco",
     "creator_is_observer": "Hai creato questa stanza e seguirai come Game Master. Non ti unirai a una squadra né invierai indizi/ipotesi.",
     "only_creator_can_start": "Solo il game master può iniziare la partita."

--- a/public/locales/pt/translation.json
+++ b/public/locales/pt/translation.json
@@ -55,6 +55,8 @@
     "join_team": "Entrar para o time",
     "join_left": "Entrar",
     "join_right": "Entrar",
+    "left_team_name": "Nome do time da esquerda",
+    "right_team_name": "Nome do time da direita",
     "start_game": "Começar partida",
     "creator_is_observer": "Você criou esta sala e acompanhará como Mestre do jogo. Você não entrará em um time nem enviará dicas/palpites.",
     "only_creator_can_start": "Apenas o mestre do jogo pode iniciar a partida."

--- a/src/components/gameplay/CounterGuess.tsx
+++ b/src/components/gameplay/CounterGuess.tsx
@@ -26,7 +26,7 @@ export function CounterGuess() {
 
   const isGameMaster = localPlayer.id === gameState.creatorId;
   const notMyTurn = isGameMaster || clueGiver.team === localPlayer.team;
-  const counterGuessTeamString = TeamName(TeamReverse(clueGiver.team), t);
+  const counterGuessTeamString = TeamName(TeamReverse(clueGiver.team), t, gameState);
 
   if (notMyTurn) {
     return (

--- a/src/components/gameplay/JoinTeam.tsx
+++ b/src/components/gameplay/JoinTeam.tsx
@@ -51,6 +51,32 @@ export function JoinTeam() {
       <LongwaveAppTitle />
       <div>{t("jointeam.join_team") as string}:</div>
       {isCreator && (
+        <CenteredRow style={{ gap: 24, margin: "8px 0" }}>
+          <div>
+            <div>{t("jointeam.left_team_name") as string}</div>
+            <input
+              type="text"
+              style={{ marginTop: 4 }}
+              value={gameState.leftTeamName}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                setGameState({ leftTeamName: e.target.value })
+              }
+            />
+          </div>
+          <div>
+            <div>{t("jointeam.right_team_name") as string}</div>
+            <input
+              type="text"
+              style={{ marginTop: 4 }}
+              value={gameState.rightTeamName}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                setGameState({ rightTeamName: e.target.value })
+              }
+            />
+          </div>
+        </CenteredRow>
+      )}
+      {isCreator && (
         <div style={{ maxWidth: 600, color: "#666", marginBottom: 8 }}>
           {t("jointeam.creator_is_observer")}
         </div>
@@ -62,7 +88,7 @@ export function JoinTeam() {
         }}
       >
         <CenteredColumn>
-          <div>{TeamName(Team.Left, t)}</div>
+          <div>{TeamName(Team.Left, t, gameState)}</div>
           {leftTeam.map((playerId) => (
             <div key={playerId}>{gameState.players[playerId].name}</div>
           ))}
@@ -76,7 +102,7 @@ export function JoinTeam() {
           )}
         </CenteredColumn>
         <CenteredColumn>
-          <div>{TeamName(Team.Right, t)}</div>
+          <div>{TeamName(Team.Right, t, gameState)}</div>
           {rightTeam.map((playerId) => (
             <div key={playerId}>{gameState.players[playerId].name}</div>
           ))}

--- a/src/components/gameplay/MakeGuess.tsx
+++ b/src/components/gameplay/MakeGuess.tsx
@@ -26,7 +26,7 @@ export function MakeGuess() {
     (gameState.gameType === GameType.Teams &&
       localPlayer.team !== clueGiver.team);
 
-  const guessingTeamString = TeamName(clueGiver.team, t);
+  const guessingTeamString = TeamName(clueGiver.team, t, gameState);
 
   if (notMyTurn) {
     return (
@@ -84,7 +84,7 @@ export function MakeGuess() {
           {!confirming ? (
             <Button
               text={t("makeguess.guess_for_team", {
-                teamname: TeamName(localPlayer.team, t),
+                teamname: TeamName(localPlayer.team, t, gameState),
               })}
               onClick={() => setConfirming(true)}
             />
@@ -92,7 +92,7 @@ export function MakeGuess() {
             <>
               <Button
                 text={t("makeguess.confirm_guess_for_team", {
-                  teamname: TeamName(localPlayer.team, t),
+                  teamname: TeamName(localPlayer.team, t, gameState),
                 })}
                 onClick={() => {
                   RecordEvent("guess_submitted", {

--- a/src/components/gameplay/Scoreboard.tsx
+++ b/src/components/gameplay/Scoreboard.tsx
@@ -71,7 +71,7 @@ function TeamColumn(props: { team: Team; score: number }) {
   return (
     <CenteredColumn style={{ alignItems: "flex-start" }}>
       <div>
-        {TeamName(props.team, t)}: <AnimatableScore score={props.score} />{" "}
+        {TeamName(props.team, t, gameState)}: <AnimatableScore score={props.score} />{" "}
         {t("scoreboard.points") as string}
       </div>
       {members.map(toPlayerRow)}

--- a/src/components/gameplay/ViewScore.tsx
+++ b/src/components/gameplay/ViewScore.tsx
@@ -54,7 +54,7 @@ export function ViewScore() {
         </div>
         {gameState.gameType === GameType.Teams && (
           <div>
-            {TeamName(TeamReverse(clueGiver.team), t)} {t("viewscore.got") as string}{" "}
+            {TeamName(TeamReverse(clueGiver.team), t, gameState)} {t("viewscore.got") as string}{" "}
             {wasCounterGuessCorrect
               ? t("viewscore.1_point_correct_guess")
               : t("viewscore.0_point_wrong_guess")}
@@ -93,6 +93,8 @@ function NextTurnOrEndGame() {
           deckSeed: gameState.deckSeed,
           deckIndex: gameState.deckIndex,
           creatorId: gameState.creatorId,
+          leftTeamName: gameState.leftTeamName,
+          rightTeamName: gameState.rightTeamName,
         });
       }}
     />
@@ -102,7 +104,7 @@ function NextTurnOrEndGame() {
     return (
       <>
         <div>
-          {t("viewscore.winning_team", { winnerteam: TeamName(Team.Left, t) }) as string}
+          {t("viewscore.winning_team", { winnerteam: TeamName(Team.Left, t, gameState) }) as string}
         </div>
         {resetButton}
       </>
@@ -116,7 +118,7 @@ function NextTurnOrEndGame() {
     return (
       <>
         <div>
-          {t("viewscore.winning_team", { winnerteam: TeamName(Team.Right, t) }) as string}
+          {t("viewscore.winning_team", { winnerteam: TeamName(Team.Right, t, gameState) }) as string}
         </div>
         {resetButton}
       </>
@@ -143,7 +145,7 @@ function NextTurnOrEndGame() {
 
   const score = GetScore(gameState.spectrumTarget, gameState.guess);
 
-  const scoringTeamString = TeamName(clueGiver.team, t);
+  const scoringTeamString = TeamName(clueGiver.team, t, gameState);
 
   let bonusTurn = false;
 

--- a/src/state/GameState.ts
+++ b/src/state/GameState.ts
@@ -33,12 +33,16 @@ export function TeamReverse(team: Team) {
   return Team.Unset;
 }
 
-export function TeamName(team: Team, t: TFunction<string>) {
+export function TeamName(team: Team, t: TFunction<string>, gameState: GameState) {
   if (team === Team.Left) {
-    return t("gamestate.left_brain");
+    return gameState.leftTeamName && gameState.leftTeamName.trim().length > 0
+      ? gameState.leftTeamName
+      : t("gamestate.left_brain");
   }
   if (team === Team.Right) {
-    return t("gamestate.right_brain");
+    return gameState.rightTeamName && gameState.rightTeamName.trim().length > 0
+      ? gameState.rightTeamName
+      : t("gamestate.right_brain");
   }
   return t("gamestate.the_player");
 }
@@ -77,6 +81,8 @@ export interface GameState {
   previousTurn: TurnSummaryModel | null;
   deckLanguage: string | null;
   creatorId: string;
+  leftTeamName: string;
+  rightTeamName: string;
 }
 
 export function InitialGameState(deckLanguage: string): GameState {
@@ -99,5 +105,7 @@ export function InitialGameState(deckLanguage: string): GameState {
     previousTurn: null,
     deckLanguage: deckLanguage,
     creatorId: "",
+    leftTeamName: "",
+    rightTeamName: "",
   };
 }


### PR DESCRIPTION
Add custom team name functionality for game masters, replacing default "LEFT BRAIN"/"RIGHT BRAIN" labels.

---
<a href="https://cursor.com/background-agent?bcId=bc-389fed28-144b-41ba-8b64-e5dbfeee6850"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-389fed28-144b-41ba-8b64-e5dbfeee6850"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

