### PR TITLE
Manage ordered card drawing for game rounds

### DIFF
--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -104,6 +104,7 @@
         "catching_up": "Aufholjagd aktiviert: {{scoringteam}} erhielt einen Bonuszug!",
         "catching_up_info": "Nachdem Dein team einen 4-Punkte Zug erreicht hat, erhält das Team einen weiteren Zug, sollte es weiterhin hinter dem anderem Team liegen.",
         "draw_next_card": "Ziehe nächste Spektrum Karte",
+        "next_round": "Nächste Runde",
         "score": "Punktestand",
         "got": "erhielt"
     }

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -104,6 +104,7 @@
     "catching_up": "Catchup activated: {{scoringteam}} takes a bonus turn!",
     "catching_up_info": "After a team scores a four-point round, they get a bonus turn if they are still behind the other team",
     "draw_next_card": "Draw next Spectrum Card",
+    "next_round": "Next round",
     "score": "Score",
     "got": "gets"
   }

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -104,6 +104,7 @@
     "catching_up": "Sprint activado: ¡el {{scoringteam}} tiene un turno extra!",
     "catching_up_info": "Cuando un equipo gana 4 puntos en una ronda, consigue un turno extra si sigue estando por detrás del otro equipo",
     "draw_next_card": "Roba la siguiente carta de espectro",
+    "next_round": "Siguiente ronda",
     "score": "Puntuación",
     "got": "obtiene"
   }

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -100,6 +100,7 @@
     "catching_up": "Rattrapage activaté : {{scoringteam}} obtient un tour bonus !",
     "catching_up_info": "Après qu'une équipe a marqué quatre points d'un coup, elle obtient un tour bonus si elle est toujours derrière l'autre équipe",
     "draw_next_card": "Dessiner la carte de plage de valeur suivante",
+    "next_round": "Manche suivante",
     "score": "Score",
     "got": "obtient"
   }

--- a/public/locales/it/translation.json
+++ b/public/locales/it/translation.json
@@ -104,6 +104,7 @@
     "catching_up": "Recupero attivato: {{scoringteam}} ottiene un turno bonus!",
     "catching_up_info": "Dopo che una squadra ha vinto un round da quattro punti, ottiene un turno bonus se è ancora dietro all'altra squadra",
     "draw_next_card": "Estrai la carta Spectrum successiva",
+    "next_round": "Prossimo turno",
     "score": "Punteggio",
     "got": "riceve"
   }

--- a/public/locales/pt/translation.json
+++ b/public/locales/pt/translation.json
@@ -100,6 +100,7 @@
     "catching_up": "Fôlego extra ativado: {{scoringteam}} ganha um turno bônus!",
     "catching_up_info": "After a team scores a four-point round, they get a bonus turn if they are still behind the other team",
     "draw_next_card": "Comprar a próxima Carta de Frequência",
+    "next_round": "Próxima rodada",
     "score": "Pontuação",
     "got": "obtém"
   }

--- a/src/components/gameplay/ViewScore.tsx
+++ b/src/components/gameplay/ViewScore.tsx
@@ -183,7 +183,7 @@ function NextTurnOrEndGame() {
       return localPlayer.id !== gameState.creatorId;
     }
 
-    return localPlayer.id !== gameState.creatorId && localPlayer.team === nextTeam;
+    return false; // In Teams mode, only the game master advances the round
   })();
 
   return (
@@ -196,16 +196,27 @@ function NextTurnOrEndGame() {
           <Info>{t("viewscore.catching_up_info") as string}</Info>
         </CenteredRow>
       )}
-      {eligibleToDraw && (
-        <Button
-          text={t("viewscore.draw_next_card") as string}
-          onClick={() =>
-            setGameState(
-              NewRound(localPlayer.id, gameState, cardsTranslation.t)
-            )
-          }
-        />
-      )}
+      {gameState.gameType === GameType.Teams
+        ? localPlayer.id === gameState.creatorId && (
+            <Button
+              text={t("viewscore.next_round") as string}
+              onClick={() =>
+                setGameState(
+                  NewRound(localPlayer.id, gameState, cardsTranslation.t)
+                )
+              }
+            />
+          )
+        : eligibleToDraw && (
+            <Button
+              text={t("viewscore.draw_next_card") as string}
+              onClick={() =>
+                setGameState(
+                  NewRound(localPlayer.id, gameState, cardsTranslation.t)
+                )
+              }
+            />
+          )}
     </>
   );
 }

--- a/src/state/GameState.ts
+++ b/src/state/GameState.ts
@@ -83,6 +83,9 @@ export interface GameState {
   creatorId: string;
   leftTeamName: string;
   rightTeamName: string;
+  // Rotation indices for selecting the next clue giver within each team
+  leftRotationIndex: number;
+  rightRotationIndex: number;
 }
 
 export function InitialGameState(deckLanguage: string): GameState {
@@ -107,5 +110,7 @@ export function InitialGameState(deckLanguage: string): GameState {
     creatorId: "",
     leftTeamName: "",
     rightTeamName: "",
+    leftRotationIndex: 0,
+    rightRotationIndex: 0,
   };
 }

--- a/src/state/NewRound.ts
+++ b/src/state/NewRound.ts
@@ -1,7 +1,8 @@
-import { RoundPhase, GameState, GameType, Team } from "./GameState";
+import { RoundPhase, GameState, GameType, Team, TeamReverse } from "./GameState";
 import { RandomSpectrumTarget } from "./RandomSpectrumTarget";
 import { BuildGameModel } from "./BuildGameModel";
 import { TFunction } from "i18next";
+import { GetScore } from "./GetScore";
 
 export function NewRound(
   playerId: string,
@@ -16,22 +17,99 @@ export function NewRound(
     () => {}
   );
 
+  // Determine next clue giver. If the creator (game master) triggers a new round
+  // in Teams mode, pick the next player on the appropriate team using rotation indices.
   let nextClueGiver = playerId;
+  let nextLeftRotationIndex = gameState.leftRotationIndex || 0;
+  let nextRightRotationIndex = gameState.rightRotationIndex || 0;
 
-  if (playerId === gameState.creatorId) {
-    const playerIds = Object.keys(gameState.players);
-    const eligiblePlayers = playerIds.filter((pid) => {
-      if (pid === gameState.creatorId) {
-        return false;
+  const playerIds = Object.keys(gameState.players);
+  const eligiblePlayers = playerIds.filter((pid) => {
+    if (pid === gameState.creatorId) {
+      return false;
+    }
+    if (gameState.gameType === GameType.Teams) {
+      return gameState.players[pid].team !== Team.Unset;
+    }
+    return true;
+  });
+
+  const leftTeamPlayers = playerIds.filter(
+    (pid) => gameState.players[pid].team === Team.Left
+  );
+  const rightTeamPlayers = playerIds.filter(
+    (pid) => gameState.players[pid].team === Team.Right
+  );
+
+  const hasPreviousClueGiver = gameModel.clueGiver !== null;
+
+  if (playerId === gameState.creatorId && gameState.gameType === GameType.Teams) {
+    if (!hasPreviousClueGiver) {
+      // First round: choose the first eligible player and set rotation index accordingly
+      if (eligiblePlayers.length > 0) {
+        nextClueGiver = eligiblePlayers[0];
+        const chosenTeam = gameState.players[nextClueGiver]?.team;
+        if (chosenTeam === Team.Left) {
+          const pos = Math.max(0, leftTeamPlayers.indexOf(nextClueGiver));
+          nextLeftRotationIndex = leftTeamPlayers.length
+            ? (pos + 1) % leftTeamPlayers.length
+            : 0;
+        } else if (chosenTeam === Team.Right) {
+          const pos = Math.max(0, rightTeamPlayers.indexOf(nextClueGiver));
+          nextRightRotationIndex = rightTeamPlayers.length
+            ? (pos + 1) % rightTeamPlayers.length
+            : 0;
+        }
       }
-      if (gameState.gameType === GameType.Teams) {
-        return gameState.players[pid].team !== Team.Unset;
+    } else {
+      // Subsequent rounds: compute which team goes next (alternating or catch-up rule)
+      const previousClueGiverTeam = gameModel.clueGiver!.team;
+      const roundScore = GetScore(gameState.spectrumTarget, gameState.guess);
+
+      let nextTeam = TeamReverse(previousClueGiverTeam);
+      if (roundScore === 4) {
+        if (
+          gameState.leftScore < gameState.rightScore &&
+          previousClueGiverTeam === Team.Left
+        ) {
+          nextTeam = Team.Left; // catch-up bonus turn
+        } else if (
+          gameState.rightScore < gameState.leftScore &&
+          previousClueGiverTeam === Team.Right
+        ) {
+          nextTeam = Team.Right; // catch-up bonus turn
+        }
       }
-      return true;
-    });
+
+      if (nextTeam === Team.Left && leftTeamPlayers.length > 0) {
+        const idx = leftTeamPlayers.length
+          ? nextLeftRotationIndex % leftTeamPlayers.length
+          : 0;
+        nextClueGiver = leftTeamPlayers[idx];
+        nextLeftRotationIndex = leftTeamPlayers.length
+          ? (idx + 1) % leftTeamPlayers.length
+          : 0;
+      } else if (nextTeam === Team.Right && rightTeamPlayers.length > 0) {
+        const idx = rightTeamPlayers.length
+          ? nextRightRotationIndex % rightTeamPlayers.length
+          : 0;
+        nextClueGiver = rightTeamPlayers[idx];
+        nextRightRotationIndex = rightTeamPlayers.length
+          ? (idx + 1) % rightTeamPlayers.length
+          : 0;
+      } else if (eligiblePlayers.length > 0) {
+        // Fallback if team arrays are empty
+        nextClueGiver = eligiblePlayers[0];
+      }
+    }
+  } else if (playerId === gameState.creatorId) {
+    // Non-team modes: still let creator choose the first eligible player
     if (eligiblePlayers.length > 0) {
       nextClueGiver = eligiblePlayers[0];
     }
+  } else {
+    // Non-creator triggering: keep previous behavior
+    nextClueGiver = playerId;
   }
 
   const newState: Partial<GameState> = {
@@ -40,6 +118,8 @@ export function NewRound(
     deckIndex: gameState.deckIndex + 1,
     turnsTaken: gameState.turnsTaken + 1,
     spectrumTarget: RandomSpectrumTarget(),
+    leftRotationIndex: nextLeftRotationIndex,
+    rightRotationIndex: nextRightRotationIndex,
   };
 
   if (gameModel.clueGiver !== null) {


### PR DESCRIPTION
Implement game master-controlled sequential player rotation for team games.

The game master now presses a "Next round" button to advance to the next player in team order, rather than any team member drawing the next card. This ensures structured player progression and game flow.

---
<a href="https://cursor.com/background-agent?bcId=bc-d7419370-360b-49b8-8d64-779a17412f5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d7419370-360b-49b8-8d64-779a17412f5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

