### PR TITLE
Remove play mode buttons and default to standard

### DIFF
--- a/src/components/gameplay/SetupGame.tsx
+++ b/src/components/gameplay/SetupGame.tsx
@@ -1,9 +1,8 @@
 import React from "react";
 import { GameType, RoundPhase } from "../../state/GameState";
-import { CenteredRow, CenteredColumn } from "../common/LayoutElements";
-import { Button } from "../common/Button";
+import { CenteredColumn } from "../common/LayoutElements";
 import { LongwaveAppTitle } from "../common/Title";
-import { useContext } from "react";
+import { useContext, useEffect } from "react";
 import { GameModelContext } from "../../state/GameModelContext";
 import { NewRound } from "../../state/NewRound";
 
@@ -31,16 +30,18 @@ export function SetupGame() {
     }
   };
 
+  useEffect(() => {
+    if (
+      gameState.roundPhase === RoundPhase.SetupGame &&
+      localPlayer.id === gameState.creatorId
+    ) {
+      startGame(GameType.Teams);
+    }
+  }, [gameState.roundPhase, gameState.creatorId, localPlayer.id, startGame]);
+
   return (
     <CenteredColumn>
       <LongwaveAppTitle />
-      <CenteredRow style={{ flexWrap: "wrap" }}>
-        <Button
-          text={t("setupgame.standard_game") as string}
-          onClick={() => startGame(GameType.Teams)}
-          disabled={localPlayer.id !== gameState.creatorId}
-        />
-      </CenteredRow>
       {localPlayer.id !== gameState.creatorId && (
         <div style={{ color: "#666", marginTop: 8 }}>
           {t("setupgame.only_creator_can_start") as string}


### PR DESCRIPTION
Remove Cooperative and Free Play room creation buttons and default to Standard (Teams) mode.

---
<a href="https://cursor.com/background-agent?bcId=bc-d6d32333-5150-4cc3-a756-5a8174f06719"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d6d32333-5150-4cc3-a756-5a8174f06719"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

