### PR TITLE
Implement game phase timer with color change

### DIFF
--- a/src/components/common/PhaseTimer.tsx
+++ b/src/components/common/PhaseTimer.tsx
@@ -1,0 +1,58 @@
+import React, { useEffect, useRef, useState } from "react";
+
+type PhaseTimerProps = {
+  // Changing this value will reset the timer to 0
+  resetKey: string | number;
+  // Optional: custom className for positioning
+  className?: string;
+};
+
+export function PhaseTimer(props: PhaseTimerProps) {
+  const { resetKey, className } = props;
+
+  const [elapsedSeconds, setElapsedSeconds] = useState<number>(0);
+  const intervalRef = useRef<number | null>(null);
+
+  // Start/Restart timer when resetKey changes
+  useEffect(() => {
+    setElapsedSeconds(0);
+
+    if (intervalRef.current !== null) {
+      window.clearInterval(intervalRef.current);
+    }
+
+    intervalRef.current = window.setInterval(() => {
+      setElapsedSeconds((prev) => prev + 1);
+    }, 1000);
+
+    return () => {
+      if (intervalRef.current !== null) {
+        window.clearInterval(intervalRef.current);
+      }
+    };
+  }, [resetKey]);
+
+  const minutes = Math.floor(elapsedSeconds / 60);
+  const seconds = elapsedSeconds % 60;
+  const isOverMinute = elapsedSeconds >= 60;
+
+  const textStyle: React.CSSProperties = {
+    fontWeight: 600,
+    color: isOverMinute ? "#c0392b" : "#333",
+  };
+
+  const containerStyle: React.CSSProperties = {
+    display: "flex",
+    justifyContent: "flex-end",
+    padding: "4px 8px",
+  };
+
+  return (
+    <div className={className} style={containerStyle}>
+      <span style={textStyle} aria-label="phase timer">
+        {minutes}:{seconds.toString().padStart(2, "0")}
+      </span>
+    </div>
+  );
+}
+

--- a/src/components/gameplay/ActiveGame.tsx
+++ b/src/components/gameplay/ActiveGame.tsx
@@ -10,6 +10,7 @@ import { CounterGuess } from "./CounterGuess";
 import { useContext } from "react";
 import { GameModelContext } from "../../state/GameModelContext";
 import { PreviousTurnResult } from "./PreviousTurnResult";
+import { PhaseTimer } from "../common/PhaseTimer";
 
 export function ActiveGame() {
   const { gameState, localPlayer } = useContext(GameModelContext);
@@ -35,6 +36,11 @@ export function ActiveGame() {
 
   return (
     <>
+      {(gameState.roundPhase === RoundPhase.GiveClue ||
+        gameState.roundPhase === RoundPhase.MakeGuess ||
+        gameState.roundPhase === RoundPhase.CounterGuess) && (
+        <PhaseTimer resetKey={gameState.roundPhase} />
+      )}
       {gameState.roundPhase === RoundPhase.GiveClue && <GiveClue />}
       {gameState.roundPhase === RoundPhase.MakeGuess && <MakeGuess />}
       {gameState.roundPhase === RoundPhase.CounterGuess && <CounterGuess />}


### PR DESCRIPTION
Add a visible timer to the Give Clue, Make Guess, and Counter Guess game phases.

This timer displays elapsed time, turns red after 60 seconds, and resets to 0 upon each phase transition.

---
<a href="https://cursor.com/background-agent?bcId=bc-36bb9bec-5f9d-438f-a482-5c4a1832077d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-36bb9bec-5f9d-438f-a482-5c4a1832077d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

