### PR TITLE
Skip player and draw new clue

### DIFF
--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -44,6 +44,7 @@
     "giveclue": {
         "waiting_for_clue": "Warte auf den Hinweis von {{givername}}",
         "draw_other_hand": "Ziehe andere Karten",
+        "skip_player": "Spieler überspringen",
         "clue": "Hinweis...",
         "instructions": "Dein Hinweis sollte sich im Spektrum zwischen den beiden Begriffe befinden und ungefähr die Position des vorgegeben Ziels zwischen diesen beiden Extremen liegen. Zum Beispiel kann 'Kaffee' ein guter Hinweis für ein warmes oder hei0es Getränk auf dem Spektrum 'heiß' und 'kalt' sein.",
         "focus1": "Beschreibe einen einzelnen Gedanken",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -44,6 +44,7 @@
   "giveclue": {
     "waiting_for_clue": "Waiting for {{givername}} to provide a clue...",
     "draw_other_hand": "Draw a different card",
+    "skip_player": "Skip player",
     "clue": "Clue...",
     "instructions": "Your clue should be some concept that lies on the provided spectrum, conceptually located where the target is between the two extremes. For example, \"coffee\" might be a good clue that lies on a spectrum of \"hot\" to \"cold\".",
     "focus1": "Convey a single thought",

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -44,6 +44,7 @@
   "giveclue": {
     "waiting_for_clue": "Esperando a que {{givername}} dé una pista...",
     "draw_other_hand": "Robar una carta distinta",
+    "skip_player": "Saltar jugador",
     "clue": "Pista...",
     "instructions": "Tu pista debería ser un concepto que encaje en el espectro dado y que se sitúe en el punto entre ambos extremos en el que está el objetivo. Por ejemplo, \"café\" podría ser una buena pista para el espectro de \"caliente\" a \"frío\".",
     "focus1": "Transmite una sola idea",

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -40,6 +40,7 @@
   "giveclue": {
     "waiting_for_clue": "En attente d'un indice à fournir par {{givername}}...",
     "draw_other_hand": "Dessiner une autre carte",
+    "skip_player": "Passer le joueur",
     "clue": "Indice...",
     "instructions": "Votre indice doit être un concept en rapport avec l'éventail de valeur donnée, situé conceptuellement là où se trouve la cible entre les deux extrêmes. Par exemple, \"café\" pourrait être un bon indice reposant sur un éventail de valeur entre \"chaud\" et \"froid\".",
     "focus1": "Formulez une seule idée",

--- a/public/locales/it/translation.json
+++ b/public/locales/it/translation.json
@@ -44,6 +44,7 @@
   "giveclue": {
     "waiting_for_clue": "In attesa che {{givername}} fornisca un indizio...",
     "draw_other_hand": "Estrai una carta diversa",
+    "skip_player": "Salta giocatore",
     "clue": "Indizio...",
     "instructions": "Il tuo indizio dovrebbe essere un concetto che si trova nello spettro fornito, concettualmente situato tra i due estremi, dove si trova il target. Ad esempio, \"caffè\" potrebbe essere un buon indizio che si trova nello spettro da \"caldo\" a \"freddo\".",
     "focus1": "Esprimi un pensiero singolo",

--- a/public/locales/pt/translation.json
+++ b/public/locales/pt/translation.json
@@ -40,6 +40,7 @@
   "giveclue": {
     "waiting_for_clue": "Esperando {{givername}} dar uma dica...",
     "draw_other_hand": "Comprar uma carta diferente",
+    "skip_player": "Pular jogador",
     "clue": "Dica...",
     "instructions": "Sua dica deve ser algum conceito dentro do espectro, localizado onde o alvo está entre os dois extremos. Por exemplo, \"café\" pode ser uma boa dica dentro do espectro de \"quente\" e \"frio\".",
     "focus1": "Use uma só ideia",

--- a/src/components/gameplay/GiveClue.tsx
+++ b/src/components/gameplay/GiveClue.tsx
@@ -119,12 +119,9 @@ export function GiveClue() {
             {t("giveclue.waiting_for_clue", { givername: clueGiver.name })}
           </div>
         </CenteredColumn>
-        {(gameState.gameType !== GameType.Cooperative && isGameMaster) ||
-        (gameState.gameType === GameType.Teams && isGameMaster) ? (
+        {gameState.gameType !== GameType.Cooperative && isGameMaster ? (
           <CenteredColumn style={{ alignItems: "flex-end" }}>
-            {gameState.gameType !== GameType.Cooperative && (
-              <Button text={t("giveclue.draw_other_hand") as string} onClick={redrawCard} />
-            )}
+            <Button text={t("giveclue.draw_other_hand") as string} onClick={redrawCard} />
             {gameState.gameType === GameType.Teams && (
               <Button text={t("giveclue.skip_player") as string} onClick={skipPlayer} />
             )}
@@ -148,12 +145,9 @@ export function GiveClue() {
 
   return (
     <div>
-      {(gameState.gameType !== GameType.Cooperative && isGameMaster) ||
-      (gameState.gameType === GameType.Teams && isGameMaster) ? (
+      {gameState.gameType !== GameType.Cooperative && isGameMaster ? (
         <CenteredColumn style={{ alignItems: "flex-end" }}>
-          {gameState.gameType !== GameType.Cooperative && (
-            <Button text={t("giveclue.draw_other_hand") as string} onClick={redrawCard} />
-          )}
+          <Button text={t("giveclue.draw_other_hand") as string} onClick={redrawCard} />
           {gameState.gameType === GameType.Teams && (
             <Button text={t("giveclue.skip_player") as string} onClick={skipPlayer} />
           )}

--- a/src/components/gameplay/GiveClue.tsx
+++ b/src/components/gameplay/GiveClue.tsx
@@ -26,6 +26,52 @@ export function GiveClue() {
       deckIndex: gameState.deckIndex + 1,
       spectrumTarget: RandomSpectrumTarget(),
     });
+
+  const skipPlayer = () => {
+    if (!clueGiver || gameState.gameType !== GameType.Teams) {
+      return;
+    }
+
+    const playerIds = Object.keys(gameState.players);
+    const leftTeamPlayers = playerIds.filter(
+      (pid) => gameState.players[pid].team === Team.Left
+    );
+    const rightTeamPlayers = playerIds.filter(
+      (pid) => gameState.players[pid].team === Team.Right
+    );
+
+    let nextClueGiverId = clueGiver.id;
+    let nextLeftRotationIndex = gameState.leftRotationIndex || 0;
+    let nextRightRotationIndex = gameState.rightRotationIndex || 0;
+
+    if (clueGiver.team === Team.Left && leftTeamPlayers.length > 0) {
+      const idx = leftTeamPlayers.length
+        ? nextLeftRotationIndex % leftTeamPlayers.length
+        : 0;
+      nextClueGiverId = leftTeamPlayers[idx];
+      nextLeftRotationIndex = leftTeamPlayers.length
+        ? (idx + 1) % leftTeamPlayers.length
+        : 0;
+    } else if (clueGiver.team === Team.Right && rightTeamPlayers.length > 0) {
+      const idx = rightTeamPlayers.length
+        ? nextRightRotationIndex % rightTeamPlayers.length
+        : 0;
+      nextClueGiverId = rightTeamPlayers[idx];
+      nextRightRotationIndex = rightTeamPlayers.length
+        ? (idx + 1) % rightTeamPlayers.length
+        : 0;
+    }
+
+    setGameState({
+      clueGiver: nextClueGiverId,
+      deckIndex: gameState.deckIndex + 1,
+      spectrumTarget: RandomSpectrumTarget(),
+      clue: "",
+      leftRotationIndex: nextLeftRotationIndex,
+      rightRotationIndex: nextRightRotationIndex,
+      roundPhase: RoundPhase.GiveClue,
+    });
+  };
   const inputElement = useRef<HTMLInputElement>(null);
   const [disableSubmit, setDisableSubmit] = useState(
     !inputElement.current?.value?.length
@@ -73,11 +119,17 @@ export function GiveClue() {
             {t("giveclue.waiting_for_clue", { givername: clueGiver.name })}
           </div>
         </CenteredColumn>
-        {gameState.gameType !== GameType.Cooperative && isGameMaster && (
+        {(gameState.gameType !== GameType.Cooperative && isGameMaster) ||
+        (gameState.gameType === GameType.Teams && isGameMaster) ? (
           <CenteredColumn style={{ alignItems: "flex-end" }}>
-            <Button text={t("giveclue.draw_other_hand") as string} onClick={redrawCard} />
+            {gameState.gameType !== GameType.Cooperative && (
+              <Button text={t("giveclue.draw_other_hand") as string} onClick={redrawCard} />
+            )}
+            {gameState.gameType === GameType.Teams && (
+              <Button text={t("giveclue.skip_player") as string} onClick={skipPlayer} />
+            )}
           </CenteredColumn>
-        )}
+        ) : null}
       </div>
     );
   }
@@ -96,11 +148,17 @@ export function GiveClue() {
 
   return (
     <div>
-      {gameState.gameType !== GameType.Cooperative && isGameMaster && (
+      {(gameState.gameType !== GameType.Cooperative && isGameMaster) ||
+      (gameState.gameType === GameType.Teams && isGameMaster) ? (
         <CenteredColumn style={{ alignItems: "flex-end" }}>
-          <Button text={t("giveclue.draw_other_hand") as string} onClick={redrawCard} />
+          {gameState.gameType !== GameType.Cooperative && (
+            <Button text={t("giveclue.draw_other_hand") as string} onClick={redrawCard} />
+          )}
+          {gameState.gameType === GameType.Teams && (
+            <Button text={t("giveclue.skip_player") as string} onClick={skipPlayer} />
+          )}
         </CenteredColumn>
-      )}
+      ) : null}
       <Animate animation="wipe-reveal-right">
         <Spectrum
           targetValue={gameState.spectrumTarget}


### PR DESCRIPTION
Add a "Skip Player" button for the game master to skip the current clue giver and draw a new card for the next player on the same team.

---
<a href="https://cursor.com/background-agent?bcId=bc-05bdd7ef-8dee-4976-9399-a10eff8c3d23"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-05bdd7ef-8dee-4976-9399-a10eff8c3d23"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

