### PR TITLE
Add team turn indicator borders

### DIFF
--- a/src/components/gameplay/GameRoom.tsx
+++ b/src/components/gameplay/GameRoom.tsx
@@ -1,5 +1,5 @@
 import { useParams } from "react-router-dom";
-import React from "react";
+import React, { useEffect } from "react";
 import { useStorageBackedState } from "../hooks/useStorageBackedState";
 import { useNetworkBackedGameState } from "../hooks/useNetworkBackedGameState";
 import { InputName } from "./InputName";
@@ -10,6 +10,7 @@ import { BuildGameModel } from "../../state/BuildGameModel";
 import { RoomIdHeader } from "../common/RoomIdHeader";
 import { FakeRooms } from "./FakeRooms";
 import { useTranslation } from "react-i18next";
+import { GameType, RoundPhase, Team } from "../../state/GameState";
 
 export function GameRoom() {
   const { roomId } = useParams<{ roomId: string }>();
@@ -75,6 +76,37 @@ export function GameRoom() {
   if (!gameState?.players?.[playerId]) {
     return null;
   }
+
+  // Toggle page border based on which team is currently acting
+  useEffect(() => {
+    const body = document.body;
+    const clear = () => body.classList.remove("left-acting", "right-acting");
+    clear();
+    try {
+      if (gameState.gameType !== GameType.Teams) return;
+      const phase = gameState.roundPhase;
+      const isActingPhase =
+        phase === RoundPhase.GiveClue ||
+        phase === RoundPhase.MakeGuess ||
+        phase === RoundPhase.CounterGuess;
+      if (!isActingPhase) return;
+      const clueGiverId = gameState.clueGiver;
+      const clueGiver = gameState.players[clueGiverId];
+      if (!clueGiver) return;
+      let actingTeam = clueGiver.team;
+      if (phase === RoundPhase.CounterGuess) {
+        actingTeam = actingTeam === Team.Left ? Team.Right : actingTeam === Team.Right ? Team.Left : Team.Unset;
+      }
+      if (actingTeam === Team.Left) {
+        body.classList.add("left-acting");
+      } else if (actingTeam === Team.Right) {
+        body.classList.add("right-acting");
+      }
+    } finally {
+      // no-op
+    }
+    return clear;
+  }, [gameState]);
 
   return (
     <GameModelContext.Provider value={gameModel}>

--- a/src/index.css
+++ b/src/index.css
@@ -16,3 +16,21 @@ ul {
   margin: 0;
   padding-inline-start: 16px;
 }
+
+/* Light border glow to indicate active team */
+body.left-acting::before,
+body.right-acting::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  box-shadow: inset 0 0 0 6px rgba(0, 0, 0, 0); /* base to reserve space */
+}
+
+body.left-acting::before {
+  box-shadow: inset 0 0 0 8px rgba(255, 0, 0, 0.25);
+}
+
+body.right-acting::before {
+  box-shadow: inset 0 0 0 8px rgba(0, 128, 255, 0.25);
+}


### PR DESCRIPTION
Add a colored page border to visually indicate which team is currently taking an action.

---
<a href="https://cursor.com/background-agent?bcId=bc-0bb7a520-dcf6-42bd-b8c2-5c1c3b3ff61d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0bb7a520-dcf6-42bd-b8c2-5c1c3b3ff61d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

