### PR TITLE
Add spectrum navigation buttons for guessers

### DIFF
--- a/src/components/gameplay/MakeGuess.tsx
+++ b/src/components/gameplay/MakeGuess.tsx
@@ -1,7 +1,7 @@
 import React, { useContext, useState } from "react";
 import { GameType, RoundPhase, TeamName } from "../../state/GameState";
 import { Spectrum } from "../common/Spectrum";
-import { CenteredColumn } from "../common/LayoutElements";
+import { CenteredColumn, CenteredRow } from "../common/LayoutElements";
 import { Button } from "../common/Button";
 import { GameModelContext } from "../../state/GameModelContext";
 import { RecordEvent } from "../../TrackEvent";
@@ -65,16 +65,36 @@ export function MakeGuess() {
 
   return (
     <div>
-      <Spectrum
-        spectrumCard={spectrumCard}
-        handleValue={gameState.guess}
-        onChange={(guess: number) => {
-          setGameState({
-            guess,
-          });
-          setConfirming(false);
-        }}
-      />
+      <CenteredRow style={{ gap: 8 }}>
+        <Button
+          text="←"
+          onClick={() => {
+            const next = Math.max(0, gameState.guess - 1);
+            setGameState({ guess: next });
+            setConfirming(false);
+          }}
+          disabled={gameState.guess <= 0}
+        />
+        <Spectrum
+          spectrumCard={spectrumCard}
+          handleValue={gameState.guess}
+          onChange={(guess: number) => {
+            setGameState({
+              guess,
+            });
+            setConfirming(false);
+          }}
+        />
+        <Button
+          text="→"
+          onClick={() => {
+            const next = Math.min(20, gameState.guess + 1);
+            setGameState({ guess: next });
+            setConfirming(false);
+          }}
+          disabled={gameState.guess >= 20}
+        />
+      </CenteredRow>
       <CenteredColumn>
         <div>
           {t("makeguess.players_clue", { givername: clueGiver.name })}:{" "}


### PR DESCRIPTION
Add left/right arrow buttons to the guesser's spectrum to enable incremental adjustment of the dial.

---
<a href="https://cursor.com/background-agent?bcId=bc-475d632b-b9f3-48c4-90f4-eaec04f13fcd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-475d632b-b9f3-48c4-90f4-eaec04f13fcd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

