### PR TITLE
Display user action helper text

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -33,6 +33,7 @@
     "the_player": "THE PLAYER"
   },
   "counterguess": {
+    "helper": "Coordinate with your team to predict whether the actual target is to the left or right of the opposing team's guess.",
     "more_left": "Target is to the left",
     "more_right": "Target is to the right",
     "confirm_more_left": "Confirm: Target is to the left",
@@ -42,6 +43,7 @@
     "waiting_guess_team": "Waiting for {{guessteam}} to guess left/right..."
   },
   "giveclue": {
+    "helper": "You're the only person who can see the colored target! Type a simple clue, which will help your teammates guess the location of the target. Then stay silent!",
     "waiting_for_clue": "Waiting for {{givername}} to provide a clue...",
     "draw_other_hand": "Draw a different card",
     "skip_player": "Skip player",
@@ -67,6 +69,7 @@
     "only_creator_can_start": "Only the game master can start the game."
   },
   "makeguess": {
+    "helper": "Coordinate with your team to guess the location of the target. Drag the dial to the desired location, then one player may submit the guess.",
     "players_clue": "{{givername}}'s clue",
     "waiting_guessing_team": "Waiting for {{guessingteam}} to guess...",
     "invite_other_players": "Invite other players to join the game.",

--- a/src/components/gameplay/CounterGuess.tsx
+++ b/src/components/gameplay/CounterGuess.tsx
@@ -49,6 +49,20 @@ export function CounterGuess() {
 
   return (
     <div>
+      <div
+        style={{
+          background: "#e2f0ff",
+          border: "1px solid #b6daff",
+          color: "#084298",
+          padding: "12px 16px",
+          borderRadius: 4,
+          margin: "12px 0",
+          fontWeight: 600,
+          textAlign: "center",
+        }}
+      >
+        {t("counterguess.helper") as string}
+      </div>
       <Spectrum spectrumCard={spectrumCard} guessingValue={gameState.guess} />
       <CenteredColumn>
         <div>

--- a/src/components/gameplay/GiveClue.tsx
+++ b/src/components/gameplay/GiveClue.tsx
@@ -145,6 +145,20 @@ export function GiveClue() {
 
   return (
     <div>
+      <div
+        style={{
+          background: "#fff3cd",
+          border: "1px solid #ffeeba",
+          color: "#856404",
+          padding: "12px 16px",
+          borderRadius: 4,
+          margin: "12px 0",
+          fontWeight: 600,
+          textAlign: "center",
+        }}
+      >
+        {t("giveclue.helper") as string}
+      </div>
       {gameState.gameType !== GameType.Cooperative && isGameMaster ? (
         <CenteredColumn style={{ alignItems: "flex-end" }}>
           <Button text={t("giveclue.draw_other_hand") as string} onClick={redrawCard} />

--- a/src/components/gameplay/MakeGuess.tsx
+++ b/src/components/gameplay/MakeGuess.tsx
@@ -65,6 +65,20 @@ export function MakeGuess() {
 
   return (
     <div>
+      <div
+        style={{
+          background: "#e2f0ff",
+          border: "1px solid #b6daff",
+          color: "#084298",
+          padding: "12px 16px",
+          borderRadius: 4,
+          margin: "12px 0",
+          fontWeight: 600,
+          textAlign: "center",
+        }}
+      >
+        {t("makeguess.helper") as string}
+      </div>
       <div style={{ position: "relative" }}>
         <Spectrum
           spectrumCard={spectrumCard}


### PR DESCRIPTION
Add prominent helper text banners to guide players during the clue, guess, and counter-guess phases.

---
<a href="https://cursor.com/background-agent?bcId=bc-d9751d38-dd2a-475d-8dd6-6dfcea9d13ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d9751d38-dd2a-475d-8dd6-6dfcea9d13ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

