### PR TITLE
Fix initial score assignment for guessing teams

### DIFF
--- a/src/state/NewGame.ts
+++ b/src/state/NewGame.ts
@@ -8,20 +8,26 @@ export function NewTeamGame(
   gameState: GameState,
   tSpectrumCards: TFunction<"spectrum-cards">
 ): Partial<GameState> {
+  // Determine the first clue giver using NewRound, then award 1 point to the
+  // opposite team (the second team to guess).
+  const nextRound = NewRound(startPlayer, gameState, tSpectrumCards);
+
   const initialScores: Partial<GameState> = {
     leftScore: 0,
     rightScore: 0,
   };
 
-  const playerTeam = players[startPlayer].team;
-  if (playerTeam === Team.Left) {
+  const firstClueGiverId = (nextRound.clueGiver as string) || "";
+  const firstClueGiverTeam = players[firstClueGiverId]?.team;
+
+  if (firstClueGiverTeam === Team.Left) {
     initialScores.rightScore = 1;
-  } else {
+  } else if (firstClueGiverTeam === Team.Right) {
     initialScores.leftScore = 1;
   }
 
   return {
-    ...NewRound(startPlayer, gameState, tSpectrumCards),
+    ...nextRound,
     ...initialScores,
     previousTurn: null,
     gameType: GameType.Teams,


### PR DESCRIPTION
Assign the initial 1 point to the second team to guess, fixing a regression where the first team incorrectly received it.

---
<a href="https://cursor.com/background-agent?bcId=bc-01c93273-cd39-4fc2-8cb8-a59f7ffda2f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-01c93273-cd39-4fc2-8cb8-a59f7ffda2f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

