### PR TITLE
Restrict player removal to game master

### DIFF
--- a/src/components/gameplay/Scoreboard.tsx
+++ b/src/components/gameplay/Scoreboard.tsx
@@ -183,9 +183,10 @@ function AnimatableScore(props: { score: number }) {
 // (helper removed; inline mapping used to avoid prop type conflicts for 'key')
 
 function PlayerRow(props: { playerId: string }) {
-  const { gameState, setGameState } = useContext(GameModelContext);
+  const { gameState, setGameState, localPlayer } = useContext(GameModelContext);
   const player = gameState.players[props.playerId];
   const [hovered, setHovered] = useState(false);
+  const isGameMaster = localPlayer.id === gameState.creatorId;
 
   const iconContainerStyle = {
     marginLeft: 4,
@@ -199,13 +200,14 @@ function PlayerRow(props: { playerId: string }) {
       onMouseLeave={() => setHovered(false)}
     >
       {player.name}
-      {hovered ? (
+      {hovered && isGameMaster ? (
         <div
           style={{
             ...iconContainerStyle,
-            cursor: "pointer",
+            cursor: isGameMaster ? "pointer" : "default",
           }}
           onClick={() => {
+            if (!isGameMaster) return;
             delete gameState.players[props.playerId];
             setGameState(gameState);
           }}


### PR DESCRIPTION
Restrict player removal from a team to only the game master to prevent unauthorized player management.

---
<a href="https://cursor.com/background-agent?bcId=bc-96de730d-65ea-4252-9220-b518f4dda5fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-96de730d-65ea-4252-9220-b518f4dda5fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

