### PR TITLE
Append new player to team roster

### DIFF
--- a/src/components/gameplay/GiveClue.tsx
+++ b/src/components/gameplay/GiveClue.tsx
@@ -33,12 +33,14 @@ export function GiveClue() {
     }
 
     const playerIds = Object.keys(gameState.players);
-    const leftTeamPlayers = playerIds.filter(
-      (pid) => gameState.players[pid].team === Team.Left
-    );
-    const rightTeamPlayers = playerIds.filter(
-      (pid) => gameState.players[pid].team === Team.Right
-    );
+    const leftTeamPlayers = (gameState.leftTeamOrder && gameState.leftTeamOrder.length
+      ? gameState.leftTeamOrder
+      : playerIds
+    ).filter((pid) => gameState.players[pid].team === Team.Left);
+    const rightTeamPlayers = (gameState.rightTeamOrder && gameState.rightTeamOrder.length
+      ? gameState.rightTeamOrder
+      : playerIds
+    ).filter((pid) => gameState.players[pid].team === Team.Right);
 
     let nextClueGiverId = clueGiver.id;
     let nextLeftRotationIndex = gameState.leftRotationIndex || 0;

--- a/src/components/gameplay/JoinTeam.tsx
+++ b/src/components/gameplay/JoinTeam.tsx
@@ -22,14 +22,22 @@ export function JoinTeam() {
   );
 
   const joinTeam = (team: Team) => {
+    // Rebuild players map so the joining player's entry is appended last.
+    // This guarantees they appear at the bottom of their team's list and
+    // preserves predictable indexing for rotations that rely on order.
+    const newPlayers: typeof gameState.players = {};
+    const playerIds = Object.keys(gameState.players);
+    for (const pid of playerIds) {
+      if (pid === localPlayer.id) continue;
+      newPlayers[pid] = gameState.players[pid];
+    }
+    newPlayers[localPlayer.id] = {
+      ...localPlayer,
+      team,
+    };
+
     setGameState({
-      players: {
-        ...gameState.players,
-        [localPlayer.id]: {
-          ...localPlayer,
-          team,
-        },
-      },
+      players: newPlayers,
     });
   };
 

--- a/src/components/gameplay/JoinTeam.tsx
+++ b/src/components/gameplay/JoinTeam.tsx
@@ -24,12 +24,14 @@ export function JoinTeam() {
     if (p?.team === Team.Left && !leftTeamBase.has(pid)) leftTeamMissing.push(pid);
     if (p?.team === Team.Right && !rightTeamBase.has(pid)) rightTeamMissing.push(pid);
   }
+  const leftBaseArray = Array.from(leftTeamBase);
+  const rightBaseArray = Array.from(rightTeamBase);
   const leftTeam: string[] = [
-    ...[...leftTeamBase].filter((pid) => gameState.players[pid]?.team === Team.Left),
+    ...leftBaseArray.filter((pid) => gameState.players[pid]?.team === Team.Left),
     ...leftTeamMissing,
   ];
   const rightTeam: string[] = [
-    ...[...rightTeamBase].filter((pid) => gameState.players[pid]?.team === Team.Right),
+    ...rightBaseArray.filter((pid) => gameState.players[pid]?.team === Team.Right),
     ...rightTeamMissing,
   ];
 

--- a/src/components/gameplay/JoinTeam.tsx
+++ b/src/components/gameplay/JoinTeam.tsx
@@ -14,10 +14,12 @@ export function JoinTeam() {
   const cardsTranslation = useTranslation("spectrum-cards");
   const { gameState, localPlayer, setGameState } = useContext(GameModelContext);
 
-  const leftTeam = Object.keys(gameState.players).filter(
+  // Derive ordered player IDs once, then filter per team to keep UI ordering consistent
+  const orderedPlayerIds = Object.keys(gameState.players);
+  const leftTeam = orderedPlayerIds.filter(
     (playerId) => gameState.players[playerId].team === Team.Left
   );
-  const rightTeam = Object.keys(gameState.players).filter(
+  const rightTeam = orderedPlayerIds.filter(
     (playerId) => gameState.players[playerId].team === Team.Right
   );
 

--- a/src/components/gameplay/Scoreboard.tsx
+++ b/src/components/gameplay/Scoreboard.tsx
@@ -21,12 +21,15 @@ export function Scoreboard() {
     alignItems: "center",
   };
 
+  // Maintain consistent player ordering everywhere by deriving ordered keys once
+  const orderedPlayerIds = Object.keys(gameState.players);
+
   if (gameState.gameType === GameType.Freeplay) {
     return (
       <CenteredColumn style={style}>
         <em>{t("scoreboard.free_play") as string}</em>
         <CenteredRow style={{ flexWrap: "wrap" }}>
-          {Object.keys(gameState.players).map((playerId) => (
+          {orderedPlayerIds.map((playerId) => (
             <PlayerRow key={playerId} playerId={playerId} />
           ))}
         </CenteredRow>
@@ -48,7 +51,7 @@ export function Scoreboard() {
             : t("scoreboard.card_remaining") + ": " + cardsRemaining}
         </div>
         <CenteredRow style={{ flexWrap: "wrap" }}>
-          {Object.keys(gameState.players).map((playerId) => (
+          {orderedPlayerIds.map((playerId) => (
             <PlayerRow key={playerId} playerId={playerId} />
           ))}
         </CenteredRow>
@@ -58,17 +61,25 @@ export function Scoreboard() {
 
   return (
     <CenteredRow style={style}>
-      <TeamColumn team={Team.Left} score={gameState.leftScore} />
-      <TeamColumn team={Team.Right} score={gameState.rightScore} />
+      <TeamColumn
+        team={Team.Left}
+        score={gameState.leftScore}
+        orderedPlayerIds={orderedPlayerIds}
+      />
+      <TeamColumn
+        team={Team.Right}
+        score={gameState.rightScore}
+        orderedPlayerIds={orderedPlayerIds}
+      />
     </CenteredRow>
   );
 }
 
-function TeamColumn(props: { team: Team; score: number }) {
+function TeamColumn(props: { team: Team; score: number; orderedPlayerIds: string[] }) {
   const { t } = useTranslation();
   const { gameState, setGameState, localPlayer } = useContext(GameModelContext);
 
-  const members = Object.keys(gameState.players).filter(
+  const members = props.orderedPlayerIds.filter(
     (playerId) => gameState.players[playerId].team === props.team
   );
 

--- a/src/components/gameplay/ViewScore.tsx
+++ b/src/components/gameplay/ViewScore.tsx
@@ -95,6 +95,8 @@ function NextTurnOrEndGame() {
           creatorId: gameState.creatorId,
           leftTeamName: gameState.leftTeamName,
           rightTeamName: gameState.rightTeamName,
+          leftTeamOrder: gameState.leftTeamOrder,
+          rightTeamOrder: gameState.rightTeamOrder,
         });
       }}
     />
@@ -183,12 +185,14 @@ function NextTurnOrEndGame() {
     const eligiblePlayers = playerIds.filter(
       (pid) => gameState.players[pid].team !== Team.Unset && pid !== gameState.creatorId
     );
-    const leftTeamPlayers = playerIds.filter(
-      (pid) => gameState.players[pid].team === Team.Left
-    );
-    const rightTeamPlayers = playerIds.filter(
-      (pid) => gameState.players[pid].team === Team.Right
-    );
+    const leftTeamPlayers = (gameState.leftTeamOrder && gameState.leftTeamOrder.length
+      ? gameState.leftTeamOrder
+      : playerIds
+    ).filter((pid) => gameState.players[pid].team === Team.Left);
+    const rightTeamPlayers = (gameState.rightTeamOrder && gameState.rightTeamOrder.length
+      ? gameState.rightTeamOrder
+      : playerIds
+    ).filter((pid) => gameState.players[pid].team === Team.Right);
 
     let nextId: string | null = null;
     if (nextTeam === Team.Left && leftTeamPlayers.length > 0) {

--- a/src/components/hooks/useNetworkBackedGameState.tsx
+++ b/src/components/hooks/useNetworkBackedGameState.tsx
@@ -40,6 +40,9 @@ export function useNetworkBackedGameState(
           name: playerName,
           team: Team.Unset,
         };
+        // Ensure order arrays exist
+        completeGameState.leftTeamOrder = completeGameState.leftTeamOrder || [];
+        completeGameState.rightTeamOrder = completeGameState.rightTeamOrder || [];
         dbRef.set(completeGameState);
         return;
       }

--- a/src/state/GameState.ts
+++ b/src/state/GameState.ts
@@ -86,6 +86,9 @@ export interface GameState {
   // Rotation indices for selecting the next clue giver within each team
   leftRotationIndex: number;
   rightRotationIndex: number;
+  // Explicit, stable ordering of players within each team
+  leftTeamOrder: string[];
+  rightTeamOrder: string[];
 }
 
 export function InitialGameState(deckLanguage: string): GameState {
@@ -112,5 +115,7 @@ export function InitialGameState(deckLanguage: string): GameState {
     rightTeamName: "",
     leftRotationIndex: 0,
     rightRotationIndex: 0,
+    leftTeamOrder: [],
+    rightTeamOrder: [],
   };
 }

--- a/src/state/NewRound.ts
+++ b/src/state/NewRound.ts
@@ -34,12 +34,14 @@ export function NewRound(
     return true;
   });
 
-  const leftTeamPlayers = playerIds.filter(
-    (pid) => gameState.players[pid].team === Team.Left
-  );
-  const rightTeamPlayers = playerIds.filter(
-    (pid) => gameState.players[pid].team === Team.Right
-  );
+  const leftTeamPlayers = (gameState.leftTeamOrder && gameState.leftTeamOrder.length
+    ? gameState.leftTeamOrder
+    : playerIds
+  ).filter((pid) => gameState.players[pid].team === Team.Left);
+  const rightTeamPlayers = (gameState.rightTeamOrder && gameState.rightTeamOrder.length
+    ? gameState.rightTeamOrder
+    : playerIds
+  ).filter((pid) => gameState.players[pid].team === Team.Right);
 
   const hasPreviousClueGiver = gameModel.clueGiver !== null;
 


### PR DESCRIPTION
This pull request contains changes generated by Cursor background composer.

<a href="https://cursor.com/background-agent?bcId=bc-b891d45a-bf8f-4dfa-9c16-618094bdffee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b891d45a-bf8f-4dfa-9c16-618094bdffee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces stable per-team ordering used across rotations and UI, updates join/remove/reset/network flows to maintain it, and adds GM +/- score controls.
> 
> - **State**:
>   - Add `leftTeamOrder`/`rightTeamOrder` to `GameState` and initialize in `InitialGameState`.
> - **Team management**:
>   - `JoinTeam`: build team lists respecting order; append joining player to the appropriate order array.
>   - `Scoreboard`: render players in stable order; removing a player also prunes them from order arrays.
>   - `ViewScore`: reset preserves team order arrays.
>   - `useNetworkBackedGameState`: ensure order arrays exist when adding a player.
> - **Turn logic**:
>   - `GiveClue` and `NewRound`: compute next clue giver using `leftTeamOrder`/`rightTeamOrder` with rotation indices; `ViewScore` next clue giver preview respects these orders.
> - **UI/Score**:
>   - `Scoreboard`: add GM-only +/- buttons to adjust team scores (clamped 0–10) and maintain consistent member ordering.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 197d3c4b4eb483adf32b665436d5a1fc5d88a92f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->