### PR TITLE
Undo clue and reassign card

### DIFF
--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -73,7 +73,8 @@
         "share_game_url": "Teile diese Adresse mit ihnen: {{game_url}}",
         "guess_for_team": "Rate für das Team {{teamname}}",
         "confirm_guess_for_team": "Bestätigen: Rate für {{teamname}}",
-        "cancel": "Abbrechen"
+        "cancel": "Abbrechen",
+        "undo_clue": "Hinweis zurücknehmen"
     },
     "previousturnresult": {
         "previous_game": "Vorheriges Spiel",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -76,7 +76,8 @@
     "share_game_url": "Share this URL with them: {{game_url}}",
     "guess_for_team": "Submit Guess for {{teamname}}",
     "confirm_guess_for_team": "Confirm Guess for {{teamname}}",
-    "cancel": "Cancel"
+    "cancel": "Cancel",
+    "undo_clue": "Undo clue"
   },
   "previousturnresult": {
     "previous_game": "Previous Turn",

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -73,7 +73,8 @@
     "share_game_url": "Comparte esta URL con ellos: {{game_url}}",
     "guess_for_team": "Enviar la respuesta del {{teamname}}",
     "confirm_guess_for_team": "Confirmar respuesta del {{teamname}}",
-    "cancel": "Cancelar"
+    "cancel": "Cancelar",
+    "undo_clue": "Deshacer pista"
   },
   "previousturnresult": {
     "previous_game": "Turno anterior",

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -69,7 +69,8 @@
     "share_game_url": "Partager cette URL avec eux : {{game_url}}",
     "guess_for_team": "Envoyer votre déduction pour {{teamname}}",
     "confirm_guess_for_team": "Confirmer la déduction pour {{teamname}}",
-    "cancel": "Annuler"
+    "cancel": "Annuler",
+    "undo_clue": "Annuler l'indice"
   },
   "previousturnresult": {
     "previous_game": "Tour précédent",

--- a/public/locales/it/translation.json
+++ b/public/locales/it/translation.json
@@ -73,7 +73,8 @@
     "share_game_url": "Condividi questo URL con loro: {{game_url}}",
     "guess_for_team": "Conferma ipotesi per la squadra {{teamname}}",
     "confirm_guess_for_team": "Conferma definitiva per {{teamname}}",
-    "cancel": "Annulla"
+    "cancel": "Annulla",
+    "undo_clue": "Annulla indizio"
   },
   "previousturnresult": {
     "previous_game": "Turno precedente",

--- a/public/locales/pt/translation.json
+++ b/public/locales/pt/translation.json
@@ -69,7 +69,8 @@
     "share_game_url": "Compartilhe esse endereço: {{game_url}}",
     "guess_for_team": "Enviar resposta por {{teamname}}",
     "confirm_guess_for_team": "Confirmar resposta por {{teamname}}",
-    "cancel": "Cancelar"
+    "cancel": "Cancelar",
+    "undo_clue": "Desfazer dica"
   },
   "previousturnresult": {
     "previous_game": "Turno Anterior",

--- a/src/components/gameplay/MakeGuess.tsx
+++ b/src/components/gameplay/MakeGuess.tsx
@@ -6,6 +6,7 @@ import { Button } from "../common/Button";
 import { GameModelContext } from "../../state/GameModelContext";
 import { RecordEvent } from "../../TrackEvent";
 import { ScoreCoopRound } from "../../state/ScoreRound";
+import { RandomSpectrumTarget } from "../../state/RandomSpectrumTarget";
 
 import { useTranslation } from "react-i18next";
 
@@ -29,6 +30,15 @@ export function MakeGuess() {
   const guessingTeamString = TeamName(clueGiver.team, t, gameState);
 
   if (notMyTurn) {
+    const undoClue = () => {
+      setGameState({
+        roundPhase: RoundPhase.GiveClue,
+        deckIndex: gameState.deckIndex + 1,
+        spectrumTarget: RandomSpectrumTarget(),
+        clue: "",
+        guess: 10,
+      });
+    };
     return (
       <div>
         <Spectrum spectrumCard={spectrumCard} guessingValue={gameState.guess} />
@@ -42,6 +52,14 @@ export function MakeGuess() {
               guessingteam: guessingTeamString,
             })}
           </div>
+          {isGameMaster && (
+            <div style={{ alignSelf: "flex-end", marginTop: 8 }}>
+              <Button
+                text={t("makeguess.undo_clue") as string}
+                onClick={undoClue}
+              />
+            </div>
+          )}
           {Object.keys(gameState.players).length < 2 && (
             <div
               style={{


### PR DESCRIPTION
This pull request contains changes generated by Cursor background composer.

<a href="https://cursor.com/background-agent?bcId=bc-2e5a296b-9b62-48d8-8530-f931ff93657d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2e5a296b-9b62-48d8-8530-f931ff93657d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a Game Master-only "Undo clue" that rewinds to clue phase with a new card/target, plus translations.
> 
> - **Gameplay (`MakeGuess.tsx`)**:
>   - Add Game Master-only `Undo clue` button when not the player's turn.
>   - Handler resets state to `RoundPhase.GiveClue`, increments `deckIndex`, sets new `spectrumTarget` via `RandomSpectrumTarget`, clears `clue`, and resets `guess` to `10`.
> - **i18n**:
>   - Add `makeguess.undo_clue` key and copy across `public/locales/{en,de,es,fr,it,pt}/translation.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c91e11078f202f3475f3143b1ba968d459ba6bee. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->