### PR TITLE
Configure game winning score

### DIFF
--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -64,7 +64,9 @@
         "right_team_name": "Name rechtes Team",
         "start_game": "Starte Spiel",
         "creator_is_observer": "Du hast diesen Raum erstellt und verfolgst als Spielleiter. Du trittst keinem Team bei und gibst keine Hinweise/Tipps ab.",
-        "only_creator_can_start": "Nur der Spielleiter kann das Spiel starten."
+        "only_creator_can_start": "Nur der Spielleiter kann das Spiel starten.",
+        "points_to_win": "Points needed to win",
+        "points_to_win_helper": "Choose a target between {{min}} and {{max}} points. Only the game master can change this."
     },
     "makeguess": {
         "players_clue": "{{givername}}'s Hinweis",
@@ -86,7 +88,8 @@
         "card_remaining": "Karten verbleiben",
         "coop_score": "Koop Punktestand",
         "points": "PUNKTE",
-        "point": "PUNKT"
+        "point": "PUNKT",
+        "playing_to": "Playing to {{points}} points"
     },
     "setupgame": {
         "standard_game": "Standard (Teams): 4+ Spieler",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -66,7 +66,9 @@
     "right_team_name": "Right team name",
     "start_game": "Start game",
     "creator_is_observer": "You created this room and are following along as Game Master. You won't join a team or submit clues/guesses.",
-    "only_creator_can_start": "Only the game master can start the game."
+    "only_creator_can_start": "Only the game master can start the game.",
+    "points_to_win": "Points needed to win",
+    "points_to_win_helper": "Choose a target between {{min}} and {{max}} points. Only the game master can change this."
   },
   "makeguess": {
     "helper": "Coordinate with your team to guess the location of the target. Drag the dial to the desired location, then one player may submit the guess.",
@@ -89,7 +91,8 @@
     "card_remaining": "Cards remaining",
     "coop_score": "Cooperative Score",
     "points": "POINTS",
-    "point": "POINT"
+    "point": "POINT",
+    "playing_to": "Playing to {{points}} points"
   },
   "setupgame": {
     "standard_game": "Standard (Teams): 4+ Players",

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -64,7 +64,9 @@
     "right_team_name": "Nombre del equipo derecho",
     "start_game": "Empezar partida",
     "creator_is_observer": "Creaste esta sala y seguirás como Maestro del juego. No te unirás a un equipo ni enviarás pistas o respuestas.",
-    "only_creator_can_start": "Solo el maestro del juego puede iniciar la partida."
+    "only_creator_can_start": "Solo el maestro del juego puede iniciar la partida.",
+    "points_to_win": "Points needed to win",
+    "points_to_win_helper": "Choose a target between {{min}} and {{max}} points. Only the game master can change this."
   },
   "makeguess": {
     "players_clue": "Pista de {{givername}}",
@@ -86,7 +88,8 @@
     "card_remaining": "Tarjetas restantes",
     "coop_score": "Puntuación cooperativa",
     "points": "PUNTOS",
-    "point": "PUNTO"
+    "point": "PUNTO",
+    "playing_to": "Playing to {{points}} points"
   },
   "setupgame": {
     "standard_game": "Estándar (por equipos): 4+ jugadores",

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -60,7 +60,9 @@
     "right_team_name": "Nom de l'équipe droite",
     "start_game": "Démarrer la partie",
     "creator_is_observer": "Vous avez créé ce salon et suivez la partie comme Maître du jeu. Vous ne rejoindrez pas d'équipe et ne soumettrez pas d'indices/déductions.",
-    "only_creator_can_start": "Seul le maître du jeu peut démarrer la partie."
+    "only_creator_can_start": "Seul le maître du jeu peut démarrer la partie.",
+    "points_to_win": "Points needed to win",
+    "points_to_win_helper": "Choose a target between {{min}} and {{max}} points. Only the game master can change this."
   },
   "makeguess": {
     "players_clue": "Indice fourni par {{givername}}",
@@ -82,7 +84,8 @@
     "card_remaining": "Cartes restantes",
     "coop_score": "Score Coopératif",
     "points": "POINTS",
-    "point": "POINT"
+    "point": "POINT",
+    "playing_to": "Playing to {{points}} points"
   },
   "setupgame": {
     "standard_game": "Standard (Équipe) : 4+ Joueurs",

--- a/public/locales/it/translation.json
+++ b/public/locales/it/translation.json
@@ -64,7 +64,9 @@
     "right_team_name": "Nome squadra destra",
     "start_game": "Avvia gioco",
     "creator_is_observer": "Hai creato questa stanza e seguirai come Game Master. Non ti unirai a una squadra né invierai indizi/ipotesi.",
-    "only_creator_can_start": "Solo il game master può iniziare la partita."
+    "only_creator_can_start": "Solo il game master può iniziare la partita.",
+    "points_to_win": "Points needed to win",
+    "points_to_win_helper": "Choose a target between {{min}} and {{max}} points. Only the game master can change this."
   },
   "makeguess": {
     "players_clue": "L'indizio di {{givername}}",
@@ -86,7 +88,8 @@
     "card_remaining": "Carte rimanenti",
     "coop_score": "Punteggio Cooperative",
     "points": "PUNTI",
-    "point": "PUNTO"
+    "point": "PUNTO",
+    "playing_to": "Playing to {{points}} points"
   },
   "setupgame": {
     "standard_game": "Classica (S): 4+ Giocatori",

--- a/public/locales/pt/translation.json
+++ b/public/locales/pt/translation.json
@@ -60,7 +60,9 @@
     "right_team_name": "Nome do time da direita",
     "start_game": "Começar partida",
     "creator_is_observer": "Você criou esta sala e acompanhará como Mestre do jogo. Você não entrará em um time nem enviará dicas/palpites.",
-    "only_creator_can_start": "Apenas o mestre do jogo pode iniciar a partida."
+    "only_creator_can_start": "Apenas o mestre do jogo pode iniciar a partida.",
+    "points_to_win": "Points needed to win",
+    "points_to_win_helper": "Choose a target between {{min}} and {{max}} points. Only the game master can change this."
   },
   "makeguess": {
     "players_clue": "Dica de {{givername}}",
@@ -82,7 +84,8 @@
     "card_remaining": "Cartas restantes",
     "coop_score": "Pontuação cooperativa",
     "points": "PONTOS",
-    "point": "PONTO"
+    "point": "PONTO",
+    "playing_to": "Playing to {{points}} points"
   },
   "setupgame": {
     "standard_game": "Padrão (Times): 4+ Jogadores",

--- a/src/components/gameplay/JoinTeam.test.tsx
+++ b/src/components/gameplay/JoinTeam.test.tsx
@@ -46,6 +46,8 @@ test("Assigns player to the selected team", async () => {
         team: Team.Left,
       },
     },
+    leftTeamOrder: ["player1"],
+    rightTeamOrder: [],
   });
 });
 

--- a/src/components/gameplay/JoinTeam.tsx
+++ b/src/components/gameplay/JoinTeam.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { CenteredRow, CenteredColumn } from "../common/LayoutElements";
-import { RoundPhase, Team, TeamName } from "../../state/GameState";
+import { DEFAULT_POINTS_TO_WIN, RoundPhase, Team, TeamName } from "../../state/GameState";
 import { Button } from "../common/Button";
 import { LongwaveAppTitle } from "../common/Title";
 import { useContext } from "react";
@@ -8,6 +8,9 @@ import { GameModelContext } from "../../state/GameModelContext";
 import { NewTeamGame } from "../../state/NewGame";
 
 import { useTranslation } from "react-i18next";
+
+const MIN_WIN_SCORE = 5;
+const MAX_WIN_SCORE = 30;
 
 export function JoinTeam() {
   const { t } = useTranslation();
@@ -78,6 +81,42 @@ export function JoinTeam() {
       )
     );
 
+  const currentPointsToWin = gameState.pointsToWin ?? DEFAULT_POINTS_TO_WIN;
+  const clampPoints = (value: number) =>
+    Math.max(MIN_WIN_SCORE, Math.min(MAX_WIN_SCORE, value));
+
+  const pointsSelector = isCreator ? (
+    <div style={{ margin: "8px 0", textAlign: "left" }}>
+      <label style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+        <span>{t("jointeam.points_to_win") as string}</span>
+        <input
+          type="number"
+          min={MIN_WIN_SCORE}
+          max={MAX_WIN_SCORE}
+          value={currentPointsToWin}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+            const raw = parseInt(e.target.value, 10);
+            if (Number.isNaN(raw)) {
+              setGameState({ pointsToWin: DEFAULT_POINTS_TO_WIN });
+              return;
+            }
+            setGameState({ pointsToWin: clampPoints(raw) });
+          }}
+        />
+      </label>
+      <div style={{ fontSize: 12, color: "#666", marginTop: 4 }}>
+        {t("jointeam.points_to_win_helper", {
+          min: MIN_WIN_SCORE,
+          max: MAX_WIN_SCORE,
+        }) as string}
+      </div>
+    </div>
+  ) : (
+    <div style={{ margin: "8px 0", color: "#666" }}>
+      {t("scoreboard.playing_to", { points: currentPointsToWin }) as string}
+    </div>
+  );
+
   return (
     <CenteredColumn>
       <LongwaveAppTitle />
@@ -108,6 +147,7 @@ export function JoinTeam() {
           </div>
         </CenteredRow>
       )}
+      {pointsSelector}
       {isCreator && (
         <div style={{ maxWidth: 600, color: "#666", marginBottom: 8 }}>
           {t("jointeam.creator_is_observer")}

--- a/src/components/gameplay/Scoreboard.tsx
+++ b/src/components/gameplay/Scoreboard.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useContext } from "react";
-import { GameType, Team, TeamName } from "../../state/GameState";
+import { DEFAULT_POINTS_TO_WIN, GameType, Team, TeamName } from "../../state/GameState";
 import { CenteredRow, CenteredColumn } from "../common/LayoutElements";
 import { GameModelContext } from "../../state/GameModelContext";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -13,12 +13,14 @@ import { useTranslation } from "react-i18next";
 export function Scoreboard() {
   const { t } = useTranslation();
   const { gameState } = useContext(GameModelContext);
+  const pointsToWin = gameState.pointsToWin ?? DEFAULT_POINTS_TO_WIN;
 
   const style = {
     borderTop: "1px solid black",
     margin: 16,
     paddingTop: 16,
     alignItems: "center",
+    width: "100%",
   };
 
   // Maintain consistent player ordering using explicit team orders if available
@@ -66,18 +68,23 @@ export function Scoreboard() {
   }
 
   return (
-    <CenteredRow style={style}>
-      <TeamColumn
-        team={Team.Left}
-        score={gameState.leftScore}
-        orderedPlayerIds={orderedPlayerIds}
-      />
-      <TeamColumn
-        team={Team.Right}
-        score={gameState.rightScore}
-        orderedPlayerIds={orderedPlayerIds}
-      />
-    </CenteredRow>
+    <CenteredColumn style={style}>
+      <div style={{ fontSize: 14, color: "#555", marginBottom: 8 }}>
+        {t("scoreboard.playing_to", { points: pointsToWin }) as string}
+      </div>
+      <CenteredRow style={{ width: "100%" }}>
+        <TeamColumn
+          team={Team.Left}
+          score={gameState.leftScore}
+          orderedPlayerIds={orderedPlayerIds}
+        />
+        <TeamColumn
+          team={Team.Right}
+          score={gameState.rightScore}
+          orderedPlayerIds={orderedPlayerIds}
+        />
+      </CenteredRow>
+    </CenteredColumn>
   );
 }
 
@@ -97,8 +104,9 @@ function TeamColumn(props: { team: Team; score: number; orderedPlayerIds: string
     if (!isGameMaster || gameState.gameType !== GameType.Teams) return;
     const key = props.team === Team.Left ? "leftScore" : "rightScore";
     const current = (gameState as any)[key] as number;
-    // Clamp between 0 and 10
-    const next = Math.max(0, Math.min(10, current + delta));
+    const maxScore = gameState.pointsToWin ?? DEFAULT_POINTS_TO_WIN;
+    // Clamp between 0 and the configured win condition
+    const next = Math.max(0, Math.min(maxScore, current + delta));
     if (next !== current) {
       setGameState({ [key]: next } as any);
     }

--- a/src/components/gameplay/ViewScore.test.tsx
+++ b/src/components/gameplay/ViewScore.test.tsx
@@ -1,6 +1,6 @@
 import { render } from "@testing-library/react";
 import { ViewScore } from "./ViewScore";
-import { InitialGameState, Team, GameState } from "../../state/GameState";
+import { InitialGameState, Team, GameState, DEFAULT_POINTS_TO_WIN } from "../../state/GameState";
 import { TestContext } from "./TestContext";
 
 const onePlayerGame: GameState = {
@@ -125,10 +125,11 @@ test("Applies catchup rule", () => {
   expect(subject).toBeInTheDocument();
 });
 
-test("Ends game when one team has 10 points", () => {
+test("Ends game when one team reaches the configured score", () => {
   const gameState = {
     ...onePlayerGame,
     leftScore: 10,
+    pointsToWin: 10,
   };
 
   const component = render(
@@ -146,6 +147,7 @@ test("Does not end game when both teams have 10 points", () => {
     ...onePlayerGame,
     leftScore: 10,
     rightScore: 10,
+    pointsToWin: 10,
   };
 
   const component = render(
@@ -156,4 +158,20 @@ test("Does not end game when both teams have 10 points", () => {
 
   const subject = component.queryByText("LEFT BRAIN wins!");
   expect(subject).toBeNull();
+});
+
+test("Defaults to 15 points needed to win", () => {
+  const gameState = {
+    ...onePlayerGame,
+    leftScore: DEFAULT_POINTS_TO_WIN,
+  };
+
+  const component = render(
+    <TestContext gameState={gameState} playerId="playerId">
+      <ViewScore />
+    </TestContext>
+  );
+
+  const subject = component.getByText("LEFT BRAIN wins!");
+  expect(subject).toBeInTheDocument();
 });

--- a/src/components/gameplay/ViewScore.tsx
+++ b/src/components/gameplay/ViewScore.tsx
@@ -9,6 +9,7 @@ import {
   InitialGameState,
   TeamName,
   TeamReverse,
+  DEFAULT_POINTS_TO_WIN,
 } from "../../state/GameState";
 import { GameModelContext } from "../../state/GameModelContext";
 import { NewRound } from "../../state/NewRound";
@@ -79,6 +80,7 @@ function NextTurnOrEndGame() {
   const cardsTranslation = useTranslation("spectrum-cards");
   const { gameState, localPlayer, clueGiver, setGameState } =
     useContext(GameModelContext);
+  const pointsToWin = gameState.pointsToWin ?? DEFAULT_POINTS_TO_WIN;
 
   if (!clueGiver) {
     return null;
@@ -97,12 +99,16 @@ function NextTurnOrEndGame() {
           rightTeamName: gameState.rightTeamName,
           leftTeamOrder: gameState.leftTeamOrder,
           rightTeamOrder: gameState.rightTeamOrder,
+          pointsToWin,
         });
       }}
     />
   );
 
-  if (gameState.leftScore >= 10 && gameState.leftScore > gameState.rightScore) {
+  if (
+    gameState.leftScore >= pointsToWin &&
+    gameState.leftScore > gameState.rightScore
+  ) {
     return (
       <>
         <div>
@@ -114,7 +120,7 @@ function NextTurnOrEndGame() {
   }
 
   if (
-    gameState.rightScore >= 10 &&
+    gameState.rightScore >= pointsToWin &&
     gameState.rightScore > gameState.leftScore
   ) {
     return (

--- a/src/components/gameplay/i18nForTests.ts
+++ b/src/components/gameplay/i18nForTests.ts
@@ -1,24 +1,23 @@
 import i18n from "i18next";
 import { initReactI18next } from "react-i18next";
-import Backend from "i18next-fs-backend";
+import translation from "../../../public/locales/en/translation.json";
+import spectrumCards from "../../../public/locales/en/spectrum-cards.json";
 
-//https://github.com/i18next/i18next-fs-backend
-
-i18n
-  .use(initReactI18next)
-  .use(Backend)
-  .init({
-    lng: "en",
-    fallbackLng: "en",
-    initImmediate: false,
-
-    interpolation: {
-      escapeValue: false, // not needed for react!!
+i18n.use(initReactI18next).init({
+  lng: "en",
+  fallbackLng: "en",
+  initImmediate: false,
+  resources: {
+    en: {
+      translation,
+      "spectrum-cards": spectrumCards as any,
     },
-
-    backend: {
-      loadPath: "public/locales/{{lng}}/{{ns}}.json",
-    },
-  });
+  },
+  ns: ["translation", "spectrum-cards"],
+  defaultNS: "translation",
+  interpolation: {
+    escapeValue: false,
+  },
+});
 
 export default i18n;

--- a/src/state/GameState.ts
+++ b/src/state/GameState.ts
@@ -2,6 +2,8 @@ import { RandomSpectrumTarget } from "./RandomSpectrumTarget";
 import { RandomFourCharacterString } from "./RandomFourCharacterString";
 import { TFunction } from "i18next";
 
+export const DEFAULT_POINTS_TO_WIN = 15;
+
 export enum RoundPhase {
   SetupGame,
   PickTeams,
@@ -83,6 +85,7 @@ export interface GameState {
   creatorId: string;
   leftTeamName: string;
   rightTeamName: string;
+  pointsToWin: number;
   // Rotation indices for selecting the next clue giver within each team
   leftRotationIndex: number;
   rightRotationIndex: number;
@@ -91,7 +94,7 @@ export interface GameState {
   rightTeamOrder: string[];
 }
 
-export function InitialGameState(deckLanguage: string): GameState {
+export function InitialGameState(deckLanguage: string = "en"): GameState {
   return {
     gameType: GameType.Teams,
     roundPhase: RoundPhase.SetupGame,
@@ -113,6 +116,7 @@ export function InitialGameState(deckLanguage: string): GameState {
     creatorId: "",
     leftTeamName: "",
     rightTeamName: "",
+    pointsToWin: DEFAULT_POINTS_TO_WIN,
     leftRotationIndex: 0,
     rightRotationIndex: 0,
     leftTeamOrder: [],


### PR DESCRIPTION
Allow the game master to configure the points needed to win a team game, defaulting to 15 points.

This provides more flexibility in game setup by replacing the hardcoded 10-point win condition with a configurable option, displayed in the UI and used for win detection and score adjustments.

---
<a href="https://cursor.com/background-agent?bcId=bc-2573ec42-c367-404f-a897-cdb129bcef3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2573ec42-c367-404f-a897-cdb129bcef3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a creator-configurable points-to-win setting (default 15) and applies it across UI, scoring logic, and tests.
> 
> - **Gameplay**:
>   - **State**: Add `pointsToWin` to `GameState` with `DEFAULT_POINTS_TO_WIN = 15`; `InitialGameState` now defaults `deckLanguage` to `"en"`.
>   - **JoinTeam**: Creator-only numeric input to set `pointsToWin` (5–30) with helper text; non-creators see `scoreboard.playing_to`.
>   - **Scoreboard**: Display `playing_to` and clamp manual score adjustments to `pointsToWin`.
>   - **ViewScore**: Use `pointsToWin` for win detection and persist it on reset.
> - **Tests**: Update `JoinTeam.test.tsx` and `ViewScore.test.tsx` for team order and configurable win; add default-15 win test; simplify test i18n setup to inline resources.
> - **i18n**: Add `jointeam.points_to_win`, `jointeam.points_to_win_helper`, and `scoreboard.playing_to` in `en`, `de`, `es`, `fr`, `it`, `pt`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1d21024952920326430cc98fadf716f0af9e7cb8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->